### PR TITLE
(duplicated handle) feat: add websocket support

### DIFF
--- a/crates/pathfinder/src/bin/pathfinder/config.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config.rs
@@ -20,6 +20,8 @@ pub enum ConfigOption {
     EthereumPassword,
     /// The HTTP-RPC listening socket address.
     HttpRpcAddress,
+    /// The RPC transport (HTTP or WS).
+    RpcTransport,
     /// Path to the node's data directory.
     DataDirectory,
     /// The Sequencer's HTTP URL.
@@ -53,6 +55,7 @@ impl Display for ConfigOption {
             ConfigOption::EthereumPassword => f.write_str("Ethereum password"),
             ConfigOption::DataDirectory => f.write_str("Data directory"),
             ConfigOption::HttpRpcAddress => f.write_str("HTTP-RPC socket address"),
+            ConfigOption::RpcTransport => f.write_str("RPC transport"),
             ConfigOption::SequencerHttpUrl => f.write_str("Sequencer HTTP URL"),
             ConfigOption::PythonSubprocesses => f.write_str("Number of Python subprocesses"),
             ConfigOption::EnableSQLiteWriteAheadLogging => {
@@ -88,6 +91,8 @@ pub struct Configuration {
     pub ethereum: EthereumConfig,
     /// The HTTP-RPC listening address and port.
     pub http_rpc_addr: SocketAddr,
+    /// The RPC transport (HTTP or WS).
+    pub rpc_transport: Option<String>,
     /// The node's data directory.
     pub data_directory: PathBuf,
     /// The Sequencer's HTTP URL.

--- a/crates/pathfinder/src/bin/pathfinder/config/builder.rs
+++ b/crates/pathfinder/src/bin/pathfinder/config/builder.rs
@@ -121,6 +121,7 @@ Hint: Register your own account or run your own Ethereum node and put the real U
             None => None,
         };
         let chain_id = self.take(ConfigOption::ChainId);
+        let rpc_transport = self.take(ConfigOption::RpcTransport);
 
         let custom_gateway = match (gateway, feeder, chain_id) {
             (None, None, None) => None,
@@ -223,6 +224,7 @@ Hint: Register your own account or run your own Ethereum node and put the real U
                 password: eth_password,
             },
             http_rpc_addr,
+            rpc_transport,
             data_directory,
             sequencer_url,
             python_subprocesses,

--- a/crates/rpc/src/test_setup.rs
+++ b/crates/rpc/src/test_setup.rs
@@ -293,8 +293,9 @@ where
         let (__handle, addr) = RpcServer::new(
             SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
             api,
+            crate::Transport::Http,
         )
-        .run()
+        .run_http()
         .await
         .unwrap();
 

--- a/crates/rpc/src/v01.rs
+++ b/crates/rpc/src/v01.rs
@@ -1977,9 +1977,9 @@ mod tests {
                 let sync_state = Arc::new(SyncState::default());
                 let api = RpcApi::new(storage, sequencer, set_chain.1, sync_state);
 
-                let (__handle, addr) = RpcServer::new(*LOCALHOST, api)
+                let (__handle, addr) = RpcServer::new(*LOCALHOST, api, crate::Transport::Http)
                     .with_middleware(RpcMetricsMiddleware)
-                    .run()
+                    .run_http()
                     .await
                     .unwrap();
                 let params = rpc_params!();
@@ -2843,9 +2843,9 @@ mod tests {
         let sequencer = Client::new(Chain::Testnet).unwrap();
         let sync_state = Arc::new(SyncState::default());
         let api = RpcApi::new(storage, sequencer, ChainId::TESTNET, sync_state);
-        let (__handle, addr) = RpcServer::new(*LOCALHOST, api)
+        let (__handle, addr) = RpcServer::new(*LOCALHOST, api, crate::Transport::Http)
             .with_middleware(RpcMetricsMiddleware)
-            .run()
+            .run_http()
             .await
             .unwrap();
 


### PR DESCRIPTION
This is a functional version of the websocket server support.

We add a Transport parameter for the RPC server and it instanciates a jsonrpsee HttpServer or WsServer.

There is a catch: our version of jsonrpsee does not contain the merge of the HttpServer and WsServer structs, they are two really separate modules. Even if they share a same API, they don't share a same trait so we can't have an handle that contain either a HttpServerHandle or WsServerHandle.