### PR TITLE
#6 Subscription events

### DIFF
--- a/crates/gateway-types/src/lib.rs
+++ b/crates/gateway-types/src/lib.rs
@@ -3,3 +3,4 @@ pub mod error;
 pub mod pending;
 pub mod reply;
 pub mod request;
+pub mod websocket;

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -773,3 +773,26 @@ mod tests {
         }
     }
 }
+
+// Types used for web socket subscription events
+pub mod ws_subscriptions {
+    use super::Block;
+    use serde::Serialize;
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct SubscriptionSyncEvent {
+        pub block: Box<Block>,
+    }
+
+    #[derive(Debug, Clone, Serialize)]
+    pub struct SubscriptionNewHeadEvent {
+        pub block: Box<Block>,
+    }
+
+    /// Events and queries emitted by L2 sync process.
+    #[derive(Debug, Clone, Serialize)]
+    pub enum SubscriptionEvent {
+        Sync(SubscriptionSyncEvent),
+        NewHead(SubscriptionNewHeadEvent),
+    }
+}

--- a/crates/gateway-types/src/reply.rs
+++ b/crates/gateway-types/src/reply.rs
@@ -773,26 +773,3 @@ mod tests {
         }
     }
 }
-
-// Types used for web socket subscription events
-pub mod ws_subscriptions {
-    use super::Block;
-    use serde::Serialize;
-
-    #[derive(Debug, Clone, Serialize)]
-    pub struct SubscriptionSyncEvent {
-        pub block: Box<Block>,
-    }
-
-    #[derive(Debug, Clone, Serialize)]
-    pub struct SubscriptionNewHeadEvent {
-        pub block: Box<Block>,
-    }
-
-    /// Events and queries emitted by L2 sync process.
-    #[derive(Debug, Clone, Serialize)]
-    pub enum SubscriptionEvent {
-        Sync(SubscriptionSyncEvent),
-        NewHead(SubscriptionNewHeadEvent),
-    }
-}

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -1,0 +1,20 @@
+// Types used for web socket subscription events
+use crate::reply::Block;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SubscriptionSyncEvent {
+    pub block: Box<Block>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SubscriptionNewHeadEvent {
+    pub block: Box<Block>,
+}
+
+/// Events and queries emitted by L2 sync process.
+#[derive(Debug, Clone, Serialize)]
+pub enum SubscriptionEvent {
+    Sync(SubscriptionSyncEvent),
+    NewHead(SubscriptionNewHeadEvent),
+}

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -27,7 +27,10 @@ use stark_hash::Felt;
 use starknet_gateway_client::ClientApi;
 use starknet_gateway_types::{
     pending::PendingData,
-    reply::{state_update::DeployedContract, Block, MaybePendingBlock, StateUpdate},
+    reply::{
+        state_update::DeployedContract, ws_subscriptions::SubscriptionEvent, Block,
+        MaybePendingBlock, StateUpdate,
+    },
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -47,7 +50,7 @@ pub async fn sync<Transport, SequencerClient, F1, F2, L1Sync, L2Sync>(
     l2_sync: L2Sync,
     pending_data: PendingData,
     pending_poll_interval: Option<std::time::Duration>,
-    event_txs: HashMap<String, broadcast::Sender<String>>,
+    event_txs: HashMap<String, broadcast::Sender<SubscriptionEvent>>,
 ) -> anyhow::Result<()>
 where
     Transport: EthereumTransport + Clone,
@@ -57,7 +60,7 @@ where
     L1Sync: FnMut(mpsc::Sender<l1::Event>, Transport, Chain, H160, Option<StateUpdateLog>) -> F1,
     L2Sync: FnOnce(
             mpsc::Sender<l2::Event>,
-            HashMap<String, broadcast::Sender<String>>,
+            HashMap<String, broadcast::Sender<SubscriptionEvent>>,
             SequencerClient,
             Option<(StarknetBlockNumber, StarknetBlockHash, GlobalRoot)>,
             Chain,
@@ -1076,7 +1079,7 @@ mod tests {
 
     async fn l2_noop(
         _: mpsc::Sender<l2::Event>,
-        _: HashMap<String, broadcast::Sender<String>>,
+        _: HashMap<String, broadcast::Sender<SubscriptionEvent>>,
         _: impl ClientApi,
         _: Option<(StarknetBlockNumber, StarknetBlockHash, GlobalRoot)>,
         _: Chain,

--- a/crates/pathfinder/src/state/sync.rs
+++ b/crates/pathfinder/src/state/sync.rs
@@ -27,10 +27,8 @@ use stark_hash::Felt;
 use starknet_gateway_client::ClientApi;
 use starknet_gateway_types::{
     pending::PendingData,
-    reply::{
-        state_update::DeployedContract, ws_subscriptions::SubscriptionEvent, Block,
-        MaybePendingBlock, StateUpdate,
-    },
+    reply::{state_update::DeployedContract, Block, MaybePendingBlock, StateUpdate},
+    websocket::SubscriptionEvent,
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -910,6 +908,7 @@ mod tests {
         pending::PendingData,
         reply,
         request::{add_transaction::ContractDefinition, BlockHashOrTag},
+        websocket::SubscriptionEvent,
     };
     use std::{collections::HashMap, sync::Arc, time::Duration};
     use tokio::sync::{broadcast, mpsc};

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -8,9 +8,9 @@ use starknet_gateway_types::{
     error::SequencerError,
     reply::{
         state_update::{DeployedContract, StateDiff},
-        ws_subscriptions::{SubscriptionEvent, SubscriptionNewHeadEvent, SubscriptionSyncEvent},
         Block, PendingBlock, StateUpdate, Status,
     },
+    websocket::{SubscriptionEvent, SubscriptionNewHeadEvent, SubscriptionSyncEvent},
 };
 use std::time::Duration;
 use std::{

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -21,6 +21,7 @@ use jsonrpsee::{
     http_server::{HttpServerBuilder, HttpServerHandle, RpcModule},
     ws_server::{WsServerBuilder, WsServerHandle},
 };
+use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
 use std::{collections::HashMap, net::SocketAddr, result::Result};
 use tokio::sync::{broadcast, RwLock};
 
@@ -60,12 +61,12 @@ impl RpcServer {
     ) -> Result<
         (
             Either<HttpServerHandle, WsServerHandle>,
-            HashMap<String, broadcast::Sender<String>>,
+            HashMap<String, broadcast::Sender<SubscriptionEvent>>,
             SocketAddr,
         ),
         anyhow::Error,
     > {
-        let mut event_txs: HashMap<String, broadcast::Sender<String>> = HashMap::new();
+        let mut event_txs: HashMap<String, broadcast::Sender<SubscriptionEvent>> = HashMap::new();
 
         match self.transport {
             Transport::Http => {
@@ -130,7 +131,7 @@ Hint: If you are looking to run two instances of pathfinder, you must configure 
     /// Starts the WS-RPC server.
     async fn run_ws(
         self,
-        event_txs: &mut HashMap<String, broadcast::Sender<String>>,
+        event_txs: &mut HashMap<String, broadcast::Sender<SubscriptionEvent>>,
     ) -> Result<(WsServerHandle, SocketAddr), jsonrpsee::core::error::Error> {
         let server = WsServerBuilder::default()
             .set_middleware(self.middleware)

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -21,7 +21,7 @@ use jsonrpsee::{
     http_server::{HttpServerBuilder, HttpServerHandle, RpcModule},
     ws_server::{WsServerBuilder, WsServerHandle},
 };
-use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
+use starknet_gateway_types::websocket::SubscriptionEvent;
 use std::{collections::HashMap, net::SocketAddr, result::Result};
 use tokio::sync::{broadcast, RwLock};
 

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use jsonrpsee::core::server::rpc_module::{Methods, PendingSubscription};
+use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
 use tokio::sync::broadcast;
 
 use crate::context::RpcContext;
@@ -111,10 +112,10 @@ impl Module {
         subscription_answer_name: &'static str,
         unsubscription_name: &'static str,
         subscription: Subscription,
-        event_txs: &mut HashMap<String, broadcast::Sender<String>>,
+        event_txs: &mut HashMap<String, broadcast::Sender<SubscriptionEvent>>,
     ) -> anyhow::Result<Self>
     where
-        Subscription: (Fn(RpcContext, PendingSubscription, &broadcast::Sender<std::string::String>))
+        Subscription: (Fn(RpcContext, PendingSubscription, &broadcast::Sender<SubscriptionEvent>))
             + Copy
             + Send
             + Sync

--- a/crates/rpc/src/module.rs
+++ b/crates/rpc/src/module.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use jsonrpsee::core::server::rpc_module::{Methods, PendingSubscription};
-use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
+use starknet_gateway_types::websocket::SubscriptionEvent;
 use tokio::sync::broadcast;
 
 use crate::context::RpcContext;

--- a/crates/rpc/src/websocket.rs
+++ b/crates/rpc/src/websocket.rs
@@ -1,4 +1,5 @@
 use jsonrpsee::core::server::rpc_module::Methods;
+use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
 use std::collections::HashMap;
 use tokio::sync::broadcast;
 
@@ -9,7 +10,7 @@ pub mod subscription;
 /// Registers all methods for the v0.2 RPC API
 pub fn register_subscriptions(
     context: RpcContext,
-    event_txs: &mut HashMap<String, broadcast::Sender<String>>,
+    event_txs: &mut HashMap<String, broadcast::Sender<SubscriptionEvent>>,
 ) -> anyhow::Result<Methods> {
     let methods = crate::module::Module::new(context)
         .register_subscription(

--- a/crates/rpc/src/websocket.rs
+++ b/crates/rpc/src/websocket.rs
@@ -1,5 +1,5 @@
 use jsonrpsee::core::server::rpc_module::Methods;
-use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
+use starknet_gateway_types::websocket::SubscriptionEvent;
 use std::collections::HashMap;
 use tokio::sync::broadcast;
 

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -1,13 +1,14 @@
 use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::core::server::rpc_module::PendingSubscription;
+use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
 pub fn subscribe_new_heads(
     _context: RpcContext,
     pending: PendingSubscription,
-    event_txs: &broadcast::Sender<std::string::String>,
+    event_txs: &broadcast::Sender<SubscriptionEvent>,
 ) {
     let event_txs = BroadcastStream::new(event_txs.subscribe());
     let mut sink = match pending.accept() {

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -1,7 +1,7 @@
 use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::core::server::rpc_module::PendingSubscription;
-use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
+use starknet_gateway_types::websocket::SubscriptionEvent;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 

--- a/crates/rpc/src/websocket/subscription/subscribe_sync.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_sync.rs
@@ -1,13 +1,14 @@
 use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::core::server::rpc_module::PendingSubscription;
+use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
 pub fn subscribe_sync(
     _context: RpcContext,
     pending: PendingSubscription,
-    event_txs: &broadcast::Sender<std::string::String>,
+    event_txs: &broadcast::Sender<SubscriptionEvent>,
 ) {
     let event_txs = BroadcastStream::new(event_txs.subscribe());
     let mut sink = match pending.accept() {

--- a/crates/rpc/src/websocket/subscription/subscribe_sync.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_sync.rs
@@ -1,7 +1,7 @@
 use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::core::server::rpc_module::PendingSubscription;
-use starknet_gateway_types::reply::ws_subscriptions::SubscriptionEvent;
+use starknet_gateway_types::websocket::SubscriptionEvent;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 


### PR DESCRIPTION
resolves #6 

### Crate `pathfinder`
Uses the new types and sends events with txs.

### Crate `rpc`

Mostly type annotations.

### Crate `gateway-types`

Types are in `crates/gateway-types/src/reply.rs`, we need `Block` type for our structs. And that is declared in `gateway-types` which depends on `common` crate. So placed the event types here instead of common.

* New `enum SubscriptionEvent`
  - `Sync`
  - `NewHead`
* New `struct SubscriptionNewHeadEvent`
  - Uses Block
* New `struct SubscriptionSyncEvent`
  - Uses Block

We can go for a `from_block` impl if we'd like the properties of `Block` to be directly in Event data instead of in one property packing everything. Let me know what ya think!