### PR TITLE
WebsocketSenders struct

### DIFF
--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -1,20 +1,29 @@
 // Types used for web socket subscription events
 use crate::reply::Block;
 use serde::Serialize;
+use tokio::sync::broadcast;
 
 #[derive(Debug, Clone, Serialize)]
-pub struct SubscriptionSyncEvent {
+pub struct WebsocketEventSync {
     pub block: Box<Block>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct SubscriptionNewHeadEvent {
+pub struct WebsocketEventNewHeadEvent {
     pub block: Box<Block>,
 }
 
-/// Events and queries emitted by L2 sync process.
-#[derive(Debug, Clone, Serialize)]
-pub enum SubscriptionEvent {
-    Sync(SubscriptionSyncEvent),
-    NewHead(SubscriptionNewHeadEvent),
+#[derive(Debug, Clone)]
+pub struct WebsocketSenders {
+    pub sync: broadcast::Sender<WebsocketEventSync>,
+    pub new_head: broadcast::Sender<WebsocketEventNewHeadEvent>,
+}
+
+impl WebsocketSenders {
+    pub fn new() -> WebsocketSenders {
+        return WebsocketSenders {
+            sync: broadcast::channel(100).0,
+            new_head: broadcast::channel(100).0,
+        };
+    }
 }

--- a/crates/gateway-types/src/websocket.rs
+++ b/crates/gateway-types/src/websocket.rs
@@ -9,14 +9,14 @@ pub struct WebsocketEventSync {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct WebsocketEventNewHeadEvent {
+pub struct WebsocketEventNewHead {
     pub block: Box<Block>,
 }
 
 #[derive(Debug, Clone)]
 pub struct WebsocketSenders {
     pub sync: broadcast::Sender<WebsocketEventSync>,
-    pub new_head: broadcast::Sender<WebsocketEventNewHeadEvent>,
+    pub new_head: broadcast::Sender<WebsocketEventNewHead>,
 }
 
 impl WebsocketSenders {

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -10,7 +10,7 @@ use starknet_gateway_types::{
         state_update::{DeployedContract, StateDiff},
         Block, PendingBlock, StateUpdate, Status,
     },
-    websocket::{WebsocketEventNewHeadEvent, WebsocketSenders},
+    websocket::{WebsocketEventNewHead, WebsocketSenders},
 };
 use std::time::Duration;
 use std::{collections::HashSet, sync::Arc};
@@ -176,7 +176,7 @@ pub async fn sync(
 
         let new_head_channel = &websocket_txs.new_head;
         if new_head_channel.receiver_count() > 0 {
-            new_head_channel.send(WebsocketEventNewHeadEvent {
+            new_head_channel.send(WebsocketEventNewHead {
                 block: block.clone(),
             })?;
         }

--- a/crates/pathfinder/src/state/sync/l2.rs
+++ b/crates/pathfinder/src/state/sync/l2.rs
@@ -10,14 +10,11 @@ use starknet_gateway_types::{
         state_update::{DeployedContract, StateDiff},
         Block, PendingBlock, StateUpdate, Status,
     },
-    websocket::{SubscriptionEvent, SubscriptionNewHeadEvent, SubscriptionSyncEvent},
+    websocket::{WebsocketEventNewHeadEvent, WebsocketSenders},
 };
 use std::time::Duration;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use std::{collections::HashSet, sync::Arc};
+use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Timings {
@@ -56,7 +53,7 @@ pub enum Event {
 
 pub async fn sync(
     tx_event: mpsc::Sender<Event>,
-    event_txs: HashMap<String, broadcast::Sender<SubscriptionEvent>>,
+    websocket_txs: WebsocketSenders,
     sequencer: impl ClientApi,
     mut head: Option<(StarknetBlockNumber, StarknetBlockHash, GlobalRoot)>,
     chain: Chain,
@@ -169,20 +166,19 @@ pub async fn sync(
             .await
             .context("Event channel closed")?;
 
-        //TODO will be replaced with hashmap based on event type once shared architecture is finalized
-        // let sync_channel = event_txs.get("starknet_subscribe_sync").unwrap();
+        // @TODO Working example to use where applicable
+        // let sync_channel = &websocket_txs.sync;
         // if sync_channel.receiver_count() > 0 {
-        //     sync_channel.send(SubscriptionEvent::Sync(SubscriptionSyncEvent {
-        //         block: block,
-        //     }))?;
+        //     sync_channel.send(WebsocketEventSync {
+        //         block: block.clone(),
+        //     })?;
         // }
 
-        //TODO will be replaced with hashmap based on event type once shared architecture is finalized
-        let new_head_channel = event_txs.get("starknet_subscribe_newHeads").unwrap();
+        let new_head_channel = &websocket_txs.new_head;
         if new_head_channel.receiver_count() > 0 {
-            new_head_channel.send(SubscriptionEvent::NewHead(SubscriptionNewHeadEvent {
+            new_head_channel.send(WebsocketEventNewHeadEvent {
                 block: block.clone(),
-            }))?;
+            })?;
         }
     }
 }
@@ -572,7 +568,6 @@ mod tests {
             reply,
         };
         use std::collections::HashMap;
-        use tokio::sync::broadcast;
 
         const DEF0: &str = r#"{
             "abi": [],
@@ -867,19 +862,12 @@ mod tests {
             use super::*;
             use pathfinder_common::Chain;
             use pretty_assertions::assert_eq;
+            use starknet_gateway_types::websocket::WebsocketSenders;
 
             #[tokio::test]
             async fn from_genesis() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -937,7 +925,14 @@ mod tests {
                 );
 
                 // Let's run the UUT
-                let _jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -978,15 +973,7 @@ mod tests {
             #[tokio::test]
             async fn resumed_after_genesis() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -1028,7 +1015,7 @@ mod tests {
                 // Let's run the UUT
                 let _jh = tokio::spawn(sync(
                     tx_event,
-                    event_txs,
+                    websocket_txs,
                     mock,
                     Some((BLOCK0_NUMBER, *BLOCK0_HASH, *GLOBAL_ROOT0)),
                     Chain::Testnet,
@@ -1060,19 +1047,12 @@ mod tests {
             use super::*;
             use pathfinder_common::Chain;
             use starknet_gateway_types::reply::Status;
+            use starknet_gateway_types::websocket::WebsocketSenders;
 
             #[tokio::test]
             async fn invalid_block_status() {
                 let (tx_event, _rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -1082,7 +1062,14 @@ mod tests {
                 block.status = Status::Reverted;
                 expect_block(&mut mock, &mut seq, BLOCK0_NUMBER.into(), Ok(block.into()));
 
-                let jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+                let jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
                 let error = jh.await.unwrap().unwrap_err();
                 assert_eq!(
                     &error.to_string(),
@@ -1095,6 +1082,7 @@ mod tests {
             use super::*;
             use pathfinder_common::Chain;
             use pretty_assertions::assert_eq;
+            use starknet_gateway_types::websocket::WebsocketSenders;
 
             #[tokio::test]
             // This reorg occurs at the genesis block, which is swapped for a new one.
@@ -1107,15 +1095,7 @@ mod tests {
             //
             async fn at_genesis_which_is_head() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -1195,7 +1175,14 @@ mod tests {
                 );
 
                 // Let's run the UUT
-                let _jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1248,15 +1235,7 @@ mod tests {
             //
             async fn at_genesis_which_is_not_head() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -1410,7 +1389,14 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1497,15 +1483,7 @@ mod tests {
             //
             async fn after_genesis_and_not_at_head() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -1700,7 +1678,14 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1782,15 +1767,7 @@ mod tests {
             //
             async fn after_genesis_and_at_head() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -1917,7 +1894,15 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -1981,15 +1966,7 @@ mod tests {
             //
             async fn parent_hash_mismatch() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 let mut mock = MockClientApi::new();
                 let mut seq = mockall::Sequence::new();
@@ -2123,7 +2100,14 @@ mod tests {
                 );
 
                 // Run the UUT
-                let _jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+                let _jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
 
                 let zstd_magic = vec![0x28, 0xb5, 0x2f, 0xfd];
 
@@ -2180,15 +2164,7 @@ mod tests {
             #[tokio::test]
             async fn shutdown() {
                 let (tx_event, mut rx_event) = tokio::sync::mpsc::channel(1);
-                let mut event_txs = HashMap::new();
-                event_txs.insert(
-                    "starknet_subscribe_newHeads".to_string(),
-                    broadcast::channel(100).0,
-                );
-                event_txs.insert(
-                    "starknet_subscribe_sync".to_string(),
-                    broadcast::channel(100).0,
-                );
+                let websocket_txs = WebsocketSenders::new();
 
                 // Closing the event's channel should trigger the sync to exit with error after the first send.
                 rx_event.close();
@@ -2210,7 +2186,15 @@ mod tests {
                 );
 
                 // Run the UUT
-                let jh = tokio::spawn(sync(tx_event, event_txs, mock, None, Chain::Testnet, None));
+
+                let jh = tokio::spawn(sync(
+                    tx_event,
+                    websocket_txs,
+                    mock,
+                    None,
+                    Chain::Testnet,
+                    None,
+                ));
 
                 // Wrap this in a timeout so we don't wait forever in case of test failure.
                 // Right now closing the channel causes an error.

--- a/crates/rpc/src/websocket.rs
+++ b/crates/rpc/src/websocket.rs
@@ -8,7 +8,7 @@ pub mod subscription;
 /// Registers all methods for the v0.2 RPC API
 pub fn register_subscriptions(
     context: RpcContext,
-    ws_broabcast_txs: WebsocketSenders,
+    ws_broadcast_txs: WebsocketSenders,
 ) -> anyhow::Result<Methods> {
     let methods = crate::module::Module::new(context)
         .register_subscription(
@@ -16,14 +16,14 @@ pub fn register_subscriptions(
             "s_newHeads",
             "starknet_unsubscribe_newHeads",
             subscription::subscribe_new_heads::subscribe_new_heads,
-            ws_broabcast_txs.new_head.clone(),
+            ws_broadcast_txs.new_head.clone(),
         )?
         .register_subscription(
             "starknet_subscribe_sync",
             "s_sync",
             "starknet_unsubscribe_sync",
             subscription::subscribe_sync::subscribe_sync,
-            ws_broabcast_txs.sync.clone(),
+            ws_broadcast_txs.sync.clone(),
         )?
         .build();
 

--- a/crates/rpc/src/websocket.rs
+++ b/crates/rpc/src/websocket.rs
@@ -1,7 +1,5 @@
 use jsonrpsee::core::server::rpc_module::Methods;
-use starknet_gateway_types::websocket::SubscriptionEvent;
-use std::collections::HashMap;
-use tokio::sync::broadcast;
+use starknet_gateway_types::websocket::WebsocketSenders;
 
 use crate::context::RpcContext;
 
@@ -10,7 +8,7 @@ pub mod subscription;
 /// Registers all methods for the v0.2 RPC API
 pub fn register_subscriptions(
     context: RpcContext,
-    event_txs: &mut HashMap<String, broadcast::Sender<SubscriptionEvent>>,
+    ws_broabcast_txs: WebsocketSenders,
 ) -> anyhow::Result<Methods> {
     let methods = crate::module::Module::new(context)
         .register_subscription(
@@ -18,14 +16,14 @@ pub fn register_subscriptions(
             "s_newHeads",
             "starknet_unsubscribe_newHeads",
             subscription::subscribe_new_heads::subscribe_new_heads,
-            event_txs,
+            ws_broabcast_txs.new_head.clone(),
         )?
         .register_subscription(
             "starknet_subscribe_sync",
             "s_sync",
             "starknet_unsubscribe_sync",
             subscription::subscribe_sync::subscribe_sync,
-            event_txs,
+            ws_broabcast_txs.sync.clone(),
         )?
         .build();
 

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -1,23 +1,23 @@
 use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::core::server::rpc_module::PendingSubscription;
-use starknet_gateway_types::websocket::SubscriptionEvent;
+use starknet_gateway_types::websocket::WebsocketEventNewHeadEvent;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
 pub fn subscribe_new_heads(
     _context: RpcContext,
     pending: PendingSubscription,
-    event_txs: &broadcast::Sender<SubscriptionEvent>,
+    ws_new_heads_tx: &broadcast::Sender<WebsocketEventNewHeadEvent>,
 ) {
-    let event_txs = BroadcastStream::new(event_txs.subscribe());
+    let ws_new_heads_tx = BroadcastStream::new(ws_new_heads_tx.subscribe());
     let mut sink = match pending.accept() {
         Some(sink) => sink,
         _ => return,
     };
 
     tokio::spawn(async move {
-        match sink.pipe_from_try_stream(event_txs).await {
+        match sink.pipe_from_try_stream(ws_new_heads_tx).await {
             SubscriptionClosed::Success => {
                 sink.close(SubscriptionClosed::Success);
             }

--- a/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
+++ b/crates/rpc/src/websocket/subscription/subscribe_new_heads.rs
@@ -1,14 +1,14 @@
 use crate::context::RpcContext;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::core::server::rpc_module::PendingSubscription;
-use starknet_gateway_types::websocket::WebsocketEventNewHeadEvent;
+use starknet_gateway_types::websocket::WebsocketEventNewHead;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
 pub fn subscribe_new_heads(
     _context: RpcContext,
     pending: PendingSubscription,
-    ws_new_heads_tx: &broadcast::Sender<WebsocketEventNewHeadEvent>,
+    ws_new_heads_tx: &broadcast::Sender<WebsocketEventNewHead>,
 ) {
     let ws_new_heads_tx = BroadcastStream::new(ws_new_heads_tx.subscribe());
     let mut sink = match pending.accept() {


### PR DESCRIPTION
### `gateway-types`
* Minor refactoring
* Removed `SubscriptionEvent` enum
* New `WebsocketSenders` struct

### `pathfinder`
* `WebsocketSenders` instead of hashmap.

### `rpc`
* `WebsocketSenders` instead of hashmap.
* Function `register_subscription`
  - directly receives the applicable `broadcast::Sender`.
  - Uses generic type `WSAnySubscriptionEvent` that is static and thread safe.

### Tests
- Mostly hashmaps replaced with `WebsocketSenders::new()`.
<img width="315" alt="image" src="https://user-images.githubusercontent.com/11048263/223841506-7d2dd3ba-60dd-47b3-8f09-8e3f66f46596.png">
